### PR TITLE
Updating the code to python3 and adding sudo to dnf execution call.

### DIFF
--- a/cnf-python3-and-sudo-fix.patch
+++ b/cnf-python3-and-sudo-fix.patch
@@ -1,0 +1,30 @@
+diff -up command-not-found-1.3/command-not-found.py.omv~ command-not-found-1.3/command-not-found.py
+--- command-not-found-1.3/command-not-found.py.omv~     2025-05-09 04:27:28.546946897 +0300
++++ command-not-found-1.3/command-not-found.py  2025-05-09 04:29:00.962390396 +0300
+@@ -5,7 +5,6 @@
+ # Licensed under GPL 2.0, see http://www.gnu.org/licenses/gpl-2.0.html
+ # for the whole text
+ 
+-from __future__ import print_function
+ import sys
+ 
+ import codecs
+@@ -104,15 +103,13 @@ def main():
+             else:
+                 pkg = binaries[param][0][1]
+                 print(_(" You can install it by typing:"), file=sys.stderr)
+-                print("    dnf install %s" % pkg, file=sys.stderr)
++                print("   sudo  dnf install %s" % pkg, file=sys.stderr)
+                 if show_inst_prompts:
+-                    res = raw_input(_('Do you want to install it? (y/N)'))
+-                    if sys.stdin.encoding and isinstance(res, str):
+-                        res = res.decode(sys.stdin.encoding)
++                    res = input(_('Do you want to install it? (y/N)'))
+                     # any not 'y' string rejects the installation
+                     res = res.lower().strip()
+                     if  res == _('y'):
+-                        os.system('dnf install ' + pkg)
++                        os.system('sudo dnf install ' + pkg)
+         return
+         
+     params = similar_words(param)

--- a/command-not-found.spec
+++ b/command-not-found.spec
@@ -1,6 +1,6 @@
 Name:           command-not-found
 Version:        1.3
-Release:        11
+Release:        12
 Summary:        Command-not-found tool for ROSA and OpenMandriva
 Group:          File tools
 License:        GPLv2
@@ -8,6 +8,7 @@ URL:            https://abf.io/soft/command-not-found
 Source0:        https://abf.io/soft/%{name}/archive/%{name}-%{version}.tar.gz
 Patch0:		cnf-1.3-dnf.patch
 Patch1:		command-not-found-fix-syntax-errors.patch
+Patch2:       cnf-python3-and-sudo-fix.patch
 BuildArch:      noarch
 
 Requires:       command-not-found-data


### PR DESCRIPTION
1. Added a patch file to bring it to python3 compatibilty by removing unneeded 
`from __future__`
changing `raw_input` call to `input` and removing encoding/decoding of the input as in python3 inputs are strings and are always utf-8

2. added `sudo` to the actual `dns install` so it can be executed

